### PR TITLE
Match advance width of inserted glyphs to the font

### DIFF
--- a/utils/ff-patch.py
+++ b/utils/ff-patch.py
@@ -51,5 +51,9 @@ for g in glyphs:
 	into.selection.select(("unicode",), ord(g))
 	into.paste()
 
+	# Match the advance width of inserted glyphs to what the target font has
+	# set on the uppercase 'E' glyph
+	into[ord(g)].width = into[0x50].width
+
 into.fontname = into.fondname = into.familyname  = into.fullname = font_name
 into.generate(save_to)


### PR DESCRIPTION
The fix for this turned out pretty trivial. I just set the width of all inserted glyphs to match what the font has set on the `E` character. In my example, the original width of `1233` gets set to `1229`.

Fixes: https://github.com/Alhadis/Menloco/issues/4

Result:

<img width="319" alt="screen shot 2018-02-25 at 18 13 36" src="https://user-images.githubusercontent.com/115237/36644286-1a553108-1a58-11e8-9578-c9d2b042f8ed.png">
