### PR TITLE
Convert scripts to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ interested in running it on another operating system, you'll need the following
 in addition to FontForge:
 
 1. Perl v5.10+
-2. Python v2.7+
+2. Python v3.6+
 3. [GNU Make](https://www.gnu.org/software/make/manual/make.html)
 
 For Windows/Cygwin, I have no idea. Have a crack at it and report any troubles.

--- a/utils/ff-extend.py
+++ b/utils/ff-extend.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import fontforge
 import re
 import sys
-
-
-# Set UTF-8 encoding
-reload(sys)
-sys.setdefaultencoding("utf8")
 
 
 # Assign a new name to the font

--- a/utils/ff-extract.py
+++ b/utils/ff-extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import fontforge
 import getopt

--- a/utils/ff-patch.py
+++ b/utils/ff-patch.py
@@ -1,14 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import fontforge
 import getopt
 import re
 import sys
-
-
-# Set UTF-8 encoding
-reload(sys)
-sys.setdefaultencoding("utf8")
 
 
 take        = ""
@@ -37,7 +32,7 @@ for key, value in options:
 
 # List of glyphs to extract from target file
 glyphs = open(glyphs_file, "r").read()
-glyphs = unicode(re.sub(ur"\s+", "", glyphs), "utf-8")
+glyphs = re.sub(r"\s+", "", glyphs)
 
 
 # Load both fonts in FontForge


### PR DESCRIPTION
`brew install fontforge` only installes the python3 module as of late forcing us to use python3 as well. Fonts seem to generate, but I'm not super literate in python, so it's possible I missed something.